### PR TITLE
fix: GraphiQL web page bugs — EXAMPLE_QUERY 404, locationQuery ReferenceError, Jinja2 HTML-escaping (issue #19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,17 @@ All notable changes to the GraphQL Integration Testing Suite.
   `graphql_ide_html` override by replacing the broken call with a
   self-contained `Object.entries`-based URL-building implementation.
 
-Both fixes are applied at runtime via the `graphql_ide_html` property override
-on `FixedGraphQLView` — no changes to the installed library are required.
+- **Fixed `"Loading..."` on page reload or shared URL** — when my fix for
+  the `locationQuery` bug (above) started writing `?query=...` into the
+  address bar, reloading the page caused Flask's `render_template_string` to
+  HTML-escape the `"` quotes in `json.dumps(request_data.query)` to `&#34;`.
+  The resulting JavaScript (`query: &#34;...&#34;`) was a `SyntaxError` that
+  silenced the entire `<script>` block and left the React root stuck on
+  "Loading...".  Fixed by wrapping every `json.dumps()` value passed to
+  `render_template_string` with `markupsafe.Markup`, which tells Jinja2 the
+  value is already safe HTML and should not be re-escaped.
+
+Both fixes are applied at runtime — no changes to the installed library are required. The `1` argument on each `replace()` call limits the substitution to the first match.
 
 ## [2.0.2] - 2026-03-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the GraphQL Integration Testing Suite.
 
+## [2.0.3] - 2026-04-16
+
+### Bug Fixes
+
+#### GraphiQL Web Interface Fixes (Issue #19)
+
+- **Fixed 404 when typing a query after the default placeholder text** — the
+  `EXAMPLE_QUERY` constant in `graphiql.html` ended with a trailing bare `#`
+  comment line before its closing backtick.  That `#` was included in the
+  request body, causing the server to return 404 instead of a GraphQL result.
+  Fixed by overriding `graphql_ide_html` on `FixedGraphQLView` in `app.py` and
+  stripping the offending line with a targeted `replace()` call.
+
+- **Fixed silent `ReferenceError` breaking URL sharing** — `updateURL()` in
+  `graphiql.html` called `locationQuery(parameters)`, a function that is never
+  defined anywhere in the file.  This raised a `ReferenceError` on every
+  keystroke, preventing the browser address bar from reflecting the current
+  query and making query URL sharing impossible.  Fixed in the same
+  `graphql_ide_html` override by replacing the broken call with a
+  self-contained `Object.entries`-based URL-building implementation.
+
+Both fixes are applied at runtime via the `graphql_ide_html` property override
+on `FixedGraphQLView` — no changes to the installed library are required.
+
 ## [2.0.2] - 2026-03-25
 
 ### New Features

--- a/grapinator/app.py
+++ b/grapinator/app.py
@@ -6,7 +6,7 @@ Flask application factory and entry point for the Grapinator GraphQL API.
 This module:
 
   1. Defines :class:`FixedGraphQLView`, a patched subclass of the upstream
-     ``GraphQLView`` that corrects four rendering bugs present in
+     ``GraphQLView`` that corrects five rendering bugs present in
      graphql-server 3.0.0.
   2. Creates and configures the Flask ``app`` instance, attaching the GraphQL
      endpoint from ``settings.FLASK_API_ENDPOINT``.
@@ -21,6 +21,7 @@ calling ``main()`` directly.
 
 import json
 from flask import Flask, Request, Response, render_template_string
+from markupsafe import Markup
 from graphql_server.flask.views import GraphQLView
 from graphql_server.http import GraphQLRequestData
 
@@ -58,6 +59,15 @@ class FixedGraphQLView(GraphQLView):
     ``locationQuery`` is never defined, causing a silent ``ReferenceError``
     on every keystroke and preventing URL sharing.  Fixed in the
     ``graphql_ide_html`` property.
+
+    **Bug 5 — Jinja2 HTML-escapes JSON values, breaking JavaScript (issue #19):**
+    Flask's ``render_template_string`` enables auto-escaping, so bare
+    ``json.dumps()`` strings have their ``"`` quotes turned into ``&#34;``
+    HTML entities.  This produces invalid JavaScript (``query: &#34;...&#34;``)
+    whenever the page is reloaded with ``?query=...`` in the URL, keeping the
+    React root stuck on "Loading...".  Fixed by wrapping all
+    ``json.dumps()`` values with ``markupsafe.Markup`` so Jinja2 skips the
+    HTML-escaping step.
     """
 
     @property
@@ -113,6 +123,11 @@ class FixedGraphQLView(GraphQLView):
         - Pass ``operation_name`` (snake_case) to match the ``{{ operation_name }}``
           placeholder in ``graphiql.html`` instead of the mismatched camelCase
           ``operationName`` keyword used by the upstream view.
+        - Wrap each value with ``markupsafe.Markup`` so Jinja2 does not
+          HTML-escape the ``"`` quotes in the JSON strings.  Without this,
+          ``render_template_string`` auto-escapes ``"`` to ``&#34;``, which
+          produces invalid JavaScript whenever the page is reloaded with a
+          ``?query=...`` URL parameter (Bug 5).
 
         :param request:      The current Flask ``Request`` object.
         :param request_data: Parsed GraphQL request fields (query, variables,
@@ -121,10 +136,10 @@ class FixedGraphQLView(GraphQLView):
         """
         return render_template_string(
             self.graphql_ide_html,
-            query=json.dumps(request_data.query),
-            variables=json.dumps(request_data.variables),
+            query=Markup(json.dumps(request_data.query)),
+            variables=Markup(json.dumps(request_data.variables)),
             # snake_case matches {{ operation_name }} in graphiql.html
-            operation_name=json.dumps(request_data.operation_name),
+            operation_name=Markup(json.dumps(request_data.operation_name)),
         )
 
 

--- a/grapinator/app.py
+++ b/grapinator/app.py
@@ -6,7 +6,7 @@ Flask application factory and entry point for the Grapinator GraphQL API.
 This module:
 
   1. Defines :class:`FixedGraphQLView`, a patched subclass of the upstream
-     ``GraphQLView`` that corrects two rendering bugs present in
+     ``GraphQLView`` that corrects four rendering bugs present in
      graphql-server 3.0.0.
   2. Creates and configures the Flask ``app`` instance, attaching the GraphQL
      endpoint from ``settings.FLASK_API_ENDPOINT``.
@@ -30,7 +30,7 @@ from grapinator.schema import gql_schema
 
 
 class FixedGraphQLView(GraphQLView):
-    """Patched ``GraphQLView`` that corrects two bugs in graphql-server 3.0.0.
+    """Patched ``GraphQLView`` that corrects four bugs in graphql-server 3.0.0.
 
     **Bug 1 — ``None`` serialised as the string ``"None"``:**
     Python's ``None`` renders as the literal string ``"None"`` inside Jinja2
@@ -46,7 +46,59 @@ class FixedGraphQLView(GraphQLView):
     leaving the placeholder empty and producing a JS ``SyntaxError``
     (``operationName: ,``).  This override uses ``operation_name`` to match
     the template variable name.
+
+    **Bug 3 — trailing empty comment line causes 404 (issue #19):**
+    The ``EXAMPLE_QUERY`` constant in ``graphiql.html`` ends with a bare
+    ``#`` comment line before its closing backtick.  When a user types after
+    the default placeholder text, that ``#`` is included in the request body
+    and the server returns a 404.  Fixed in the ``graphql_ide_html`` property.
+
+    **Bug 4 — ``locationQuery`` is undefined (issue #19):**
+    The ``updateURL()`` function calls ``locationQuery(parameters)``, but
+    ``locationQuery`` is never defined, causing a silent ``ReferenceError``
+    on every keystroke and preventing URL sharing.  Fixed in the
+    ``graphql_ide_html`` property.
     """
+
+    @property
+    def graphql_ide_html(self) -> str:
+        """
+        Return the GraphiQL IDE HTML with two upstream bugs patched in-place.
+
+        **Bug 3 — trailing empty comment causes 404:**
+        The ``EXAMPLE_QUERY`` constant in ``graphiql.html`` ends with a lone
+        ``#`` comment line immediately before the closing backtick.  When a
+        user types a query after the default placeholder text, that bare ``#``
+        is included in the request body, causing the server to return a 404
+        instead of a GraphQL result.  The fix removes that trailing ``#\\n``
+        before the closing backtick.
+
+        **Bug 4 — ``locationQuery`` is undefined:**
+        The ``updateURL()`` function in ``graphiql.html`` calls
+        ``locationQuery(parameters)``, but ``locationQuery`` is never defined
+        anywhere in the file.  This raises a silent ``ReferenceError`` in the
+        browser console on every keystroke and prevents the address bar from
+        reflecting the current query (breaking URL sharing).  The fix replaces
+        the broken call with a self-contained URL-building implementation.
+        """
+        html = super().graphql_ide_html
+        # Fix 3: remove the trailing empty comment line from EXAMPLE_QUERY.
+        # That lone '#\n' before the closing backtick is included in requests
+        # typed after the default text, causing a 404 response.
+        html = html.replace('#\n`;\n', '`;\n', 1)
+        # Fix 4: locationQuery is never defined; replace with a working
+        # URL-building implementation so the address bar reflects the query.
+        html = html.replace(
+            'history.replaceState(null, null, locationQuery(parameters));',
+            'var p = Object.entries(parameters)'
+            '.filter(([,v]) => v !== undefined && v !== null && v !== "")'
+            '.map(([k,v]) => encodeURIComponent(k)+"="+encodeURIComponent(v))'
+            '.join("&");'
+            'history.replaceState(null, null,'
+            ' window.location.pathname + (p ? "?"+p : ""));',
+            1,
+        )
+        return html
 
     def render_graphql_ide(
         self, request: Request, request_data: GraphQLRequestData

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = grapinator
-version = 2.0.2
+version = 2.0.3
 author = NREL
 description = Dynamic GraphQL API Creator
 long_description = file: README.md

--- a/tests/test_flask_app.py
+++ b/tests/test_flask_app.py
@@ -2,10 +2,12 @@
 
 Covers:
   - SecurityHeadersMiddleware : security response headers (svc_cherrypy.py)
-  - FixedGraphQLView          : the two bug-fixes for render_graphql_ide
+  - FixedGraphQLView          : bug-fixes for render_graphql_ide / graphql_ide_html
       Bug 1 — None rendered as JSON null (not Python 'None' string)
       Bug 2 — operation_name passed with snake_case key so the template
               {{operation_name}} is populated correctly
+      Bug 5 — json.dumps values must not be HTML-escaped by Jinja2
+              (would turn \" into &#34;, breaking JavaScript on page reload)
 """
 
 import os
@@ -328,14 +330,13 @@ class TestFixedGraphQLViewNullRendering(unittest.TestCase):
     def test_string_query_is_json_encoded(self):
         content = self._render(query='{ employees { name } }',
                                template='{{ query }}')
-        # json.dumps wraps the string in double-quotes; Jinja2 HTML-escapes them
-        self.assertEqual(html.unescape(content),
-                         json.dumps('{ employees { name } }'))
+        # Markup prevents auto-escaping, so content has raw quotes
+        self.assertEqual(content, json.dumps('{ employees { name } }'))
 
     def test_dict_variables_is_json_encoded(self):
         variables = {'first': 10}
         content = self._render(variables=variables, template='{{ variables }}')
-        self.assertEqual(json.loads(html.unescape(content)), variables)
+        self.assertEqual(json.loads(content), variables)
 
 
 # ---------------------------------------------------------------------------
@@ -364,8 +365,7 @@ class TestFixedGraphQLViewOperationNameKey(unittest.TestCase):
     def test_operation_name_template_var_is_populated(self):
         """The snake_case template variable must not be empty."""
         content = self._render_op_name('MyQuery')
-        # json.dumps('MyQuery') == '"MyQuery"'; Jinja2 HTML-escapes quotes
-        self.assertIn('MyQuery', html.unescape(content))
+        self.assertIn('MyQuery', content)
 
     def test_none_operation_name_renders_null_not_empty(self):
         content = self._render_op_name(None)
@@ -377,6 +377,69 @@ class TestFixedGraphQLViewOperationNameKey(unittest.TestCase):
         content = self._render_op_name('GetEmployees')
         self.assertNotEqual(content, '')
         self.assertNotEqual(content, 'null')
+
+
+# ---------------------------------------------------------------------------
+# FixedGraphQLView — Bug 5: no HTML-escaping of JSON template values
+# ---------------------------------------------------------------------------
+
+class TestFixedGraphQLViewNoHtmlEscaping(unittest.TestCase):
+    """Bug 5 fix: json.dumps values must reach the template as raw JavaScript
+    literals, not HTML-entity-encoded strings.
+
+    Flask's render_template_string enables Jinja2 auto-escaping.  Without
+    markupsafe.Markup the double-quote characters in json.dumps output are
+    turned into ``&#34;`` (or ``&quot;``), which is invalid JavaScript and
+    leaves the React root stuck on "Loading..." when the page is reloaded
+    with a ``?query=...`` URL parameter.
+    """
+
+    def _render_raw(self, query=None, variables=None, operation_name=None,
+                    template='{{query}}|{{variables}}|{{operation_name}}'):
+        request_data = MagicMock()
+        request_data.query          = query
+        request_data.variables      = variables
+        request_data.operation_name = operation_name
+
+        with patch.object(GraphQLView, 'graphql_ide_html',
+                          new_callable=PropertyMock, return_value=template):
+            view = object.__new__(FixedGraphQLView)
+            with app.test_request_context('/'):
+                result = view.render_graphql_ide(MagicMock(), request_data)
+        return result if isinstance(result, str) else result.get_data(as_text=True)
+
+    def test_string_query_contains_raw_quotes_not_entities(self):
+        """A string query must appear with raw " characters, not &#34;."""
+        content = self._render_raw(query='{ employees { name } }',
+                                   template='{{ query }}')
+        self.assertNotIn('&#34;', content)
+        self.assertNotIn('&quot;', content)
+        self.assertIn('"', content)
+
+    def test_dict_variables_contains_raw_quotes_not_entities(self):
+        content = self._render_raw(variables={'limit': 5},
+                                   template='{{ variables }}')
+        self.assertNotIn('&#34;', content)
+        self.assertNotIn('&quot;', content)
+
+    def test_string_operation_name_contains_raw_quotes_not_entities(self):
+        content = self._render_raw(operation_name='GetEmployees',
+                                   template='{{ operation_name }}')
+        self.assertNotIn('&#34;', content)
+        self.assertNotIn('&quot;', content)
+        self.assertIn('"', content)
+
+    def test_rendered_query_is_valid_json(self):
+        """The rendered query value must be parseable as JSON (valid JS literal)."""
+        query = '{ employees { firstName lastName } }'
+        content = self._render_raw(query=query, template='{{ query }}')
+        self.assertEqual(json.loads(content), query)
+
+    def test_rendered_variables_is_valid_json(self):
+        variables = {'city': 'Seattle', 'limit': 10}
+        content = self._render_raw(variables=variables,
+                                   template='{{ variables }}')
+        self.assertEqual(json.loads(content), variables)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Fixes all bugs described in issue #19 plus a follow-up regression introduced by the locationQuery fix.

## Changes

### `grapinator/app.py`
Added `graphql_ide_html` property override and `Markup` import to `FixedGraphQLView`:

**Bug 3** — Trailing empty comment line in `EXAMPLE_QUERY` caused 404 when a user typed a query after the default placeholder text. The lone `#\n` before the closing backtick was included in the request body. Fixed with `html.replace('#\n`;\n', '`;\n', 1)`.

**Bug 4** — `updateURL()` called `locationQuery(parameters)` which is never defined, raising a silent `ReferenceError` on every keystroke and preventing URL sharing. Fixed by replacing the broken call w**Bug 4** — `updateURL()` called `locationQuery(paramet**Bug 5** — Flask's `render_templat**Bug 4** — `es**Bug 4** — `updateURL()` called `valid**Bug 4** — `updateURL()` called `locationQuery(parameters)` which is never defined, raising a silent `ReferenceError\ al**Bug 4** — `` val**Bug 4** — `updateURL()` called `locationQuery(parameters)` which is never defined, raising mlEsc**Bug 4*(5 n**Bug 4** — `updateURre**Bug 4** — `updateURL()` called `locationQuery(parameters)` which is never defined, prevents escaping

### `CHANGELOG.md` / `setup.cfg`
- Added `[2.0.3]` entry documenting all three fixes
- Bumped version to `2.0.3`

## Tests
49 tests pass (44 existing + 5 new).

Closes #19