### PR TITLE
fix: preserve extra URL params in GraphiQL updateURL (issue #19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the GraphQL Integration Testing Suite.
 
+## [2.0.4] - 2026-04-16
+
+### Bug Fixes
+
+#### GraphiQL Web Interface Fix — Preserve extra URL parameters (Issue #19)
+
+- **Fixed extra URL query parameters being dropped by `updateURL()`** — the
+  `locationQuery` replacement introduced in 2.0.3 built the address-bar URL
+  from scratch using only the GraphiQL-managed parameters (query, variables,
+  operationName), silently discarding any other parameters already present in
+  the URL (e.g. `api_key=12345` in `northwind/gql?api_key=12345`).  Fixed by
+  seeding the URL builder with `new URLSearchParams(window.location.search)`
+  so that non-GraphiQL parameters are preserved; GraphiQL-managed keys are
+  then set or deleted on top of the existing params before the URL is written
+  back via `history.replaceState`.
+
 ## [2.0.3] - 2026-04-16
 
 ### Bug Fixes

--- a/grapinator/app.py
+++ b/grapinator/app.py
@@ -98,14 +98,18 @@ class FixedGraphQLView(GraphQLView):
         html = html.replace('#\n`;\n', '`;\n', 1)
         # Fix 4: locationQuery is never defined; replace with a working
         # URL-building implementation so the address bar reflects the query.
+        # Starts from the current search params so that non-GraphiQL parameters
+        # (e.g. api_key=…) passed in the original URL are preserved.
         html = html.replace(
             'history.replaceState(null, null, locationQuery(parameters));',
-            'var p = Object.entries(parameters)'
-            '.filter(([,v]) => v !== undefined && v !== null && v !== "")'
-            '.map(([k,v]) => encodeURIComponent(k)+"="+encodeURIComponent(v))'
-            '.join("&");'
-            'history.replaceState(null, null,'
-            ' window.location.pathname + (p ? "?"+p : ""));',
+            'var _sp = new URLSearchParams(window.location.search);'
+            'Object.entries(parameters).forEach(function(e){'
+            ' if(e[1]!==undefined&&e[1]!==null&&e[1]!==""){_sp.set(e[0],e[1]);}'
+            ' else{_sp.delete(e[0]);}'
+            '});'
+            'var _p=_sp.toString();'
+            'history.replaceState(null,null,'
+            ' window.location.pathname+(_p?"?"+_p:""));',
             1,
         )
         return html


### PR DESCRIPTION
## Summary

The `locationQuery` replacement in v2.0.3 rebuilt the address-bar URL using only the three GraphiQL-managed parameters (query, variables, operationName), silently discarding any other query parameters already present in the URL.

### Example of the problem
`northwind/gql?api_key=12345` — after the first keystroke in GraphiQL, `api_key=12345` would be dropped from the URL.

## Fix
Seeds the URL builder with `new URLSearchParams(window.location.search)` so non-GraphiQL parameters are preserved. GraphiQL-managed keys are then set or deleted on top of the existing params before `history.replaceState` is called.

## Changelog
See [2.0.4] entry in CHANGELOG.md.

Closes #19