### PR TITLE
fix: build SQLALCHEMY_DATABASE_URI before redacting DB_PASSWORD (v2.1.8, closes #25)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ docker/resources/instantclient*
 docker/resources/oracle*
 mariadb/*
 venv/*
+grapinator/resources.test/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -87,7 +88,7 @@ celerybeat-schedule
 *.sage.py
 
 # dotenv
-#.env
+.env
 
 # virtualenv
 .venv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to Grapinator
 
 ## [Unreleased]
 
+## [2.1.8] - 2026-04-29
+
+### Fixed
+
+- **`_RedactedStr` embeds `***REDACTED***` into `SQLALCHEMY_DATABASE_URI`, causing ORA-01017** (`grapinator/settings.py`, issue #25)
+  — When credential redaction was introduced in v2.1.5, `DB_PASSWORD` was
+  wrapped in `_RedactedStr` *before* the `SQLALCHEMY_DATABASE_URI` f-string
+  was built.  Because `_RedactedStr` overrides `__str__` to return
+  `'***REDACTED***'`, and Python f-strings invoke `__str__` on embedded
+  objects, the URI contained the literal string `***REDACTED***` as the
+  password.  Oracle (and any other non-SQLite database) rejected every
+  connection with `ORA-01017: invalid username/password; logon denied`.
+  Fixed by building the URI with the plaintext password first, then wrapping
+  `DB_PASSWORD` in `_RedactedStr`.  The URI itself remains wrapped in
+  `_RedactedStr` so credentials are still redacted in log output.
+
 ### Added
 
 #### GraphQL Integration Test Runner sub-project (Issue #22)

--- a/grapinator/settings.py
+++ b/grapinator/settings.py
@@ -243,15 +243,20 @@ class Settings(object):
             # Both DB_PASSWORD and SQLALCHEMY_DATABASE_URI are wrapped in
             # _RedactedStr so accidental logging of the Settings object never
             # exposes credentials in plaintext log output.
+            # IMPORTANT: build the URI with the plaintext password BEFORE
+            # wrapping DB_PASSWORD in _RedactedStr.  _RedactedStr overrides
+            # __str__ to return '***REDACTED***', so using it inside an
+            # f-string would embed the literal string '***REDACTED***' in the
+            # URI instead of the real password, causing ORA-01017 / auth errors.
             if 'sqlite' in self.DB_TYPE:
                 self.SQLALCHEMY_DATABASE_URI = _RedactedStr(
                     f"{self.DB_TYPE}://{self.DB_CONNECT}"
                 )
             else:
-                self.DB_PASSWORD = _RedactedStr(self.DB_PASSWORD)
                 self.SQLALCHEMY_DATABASE_URI = _RedactedStr(
                     f"{self.DB_TYPE}://{self.DB_USER}:{self.DB_PASSWORD}@{self.DB_CONNECT}"
                 )
+                self.DB_PASSWORD = _RedactedStr(self.DB_PASSWORD)
 
             self.SQLALCHEMY_TRACK_MODIFICATIONS = properties.getboolean('SQLALCHEMY', 'SQLALCHEMY_TRACK_MODIFICATIONS')
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = grapinator
-version = 2.1.7
+version = 2.1.8
 author = NREL
 description = Dynamic GraphQL API Creator
 long_description = file: README.md


### PR DESCRIPTION
## Summary

Fixes #25

`_RedactedStr` overrides `__str__` to return `'***REDACTED***'`.  When `DB_PASSWORD` was wrapped in `_RedactedStr` *before* the `SQLALCHEMY_DATABASE_URI` f-string was constructed, Python's f-string interpolation called `__str__` and embedded the literal string `***REDACTED***` as the password in the URI.  Oracle (and other non-SQLite databases) rejected every connection with:

```
ORA-01017: invalid username/password; logon denied
```

## Changes

- `grapinator/settings.py` — build `SQLALCHEMY_DATABASE_URI` with the plaintext password first, then wrap `DB_PASSWORD` in `_RedactedStr`
- `CHANGELOG.md` — add v2.1.8 entry
- `setup.cfg` — bump version to 2.1.8
- `.gitignore` — add `grapinator/resources.test/`