### PR TITLE
feat: configurable Oracle per-call timeout via DB_CALL_TIMEOUT (issue #31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to Grapinator
 
+## [2.1.11] - 2026-06-16
+
+### Added
+
+- **Configurable per-call timeout for the Oracle driver** (`grapinator/settings.py`,
+  `grapinator/model.py`, issue #31)
+  — A new optional `[SQLALCHEMY]` INI key, `DB_CALL_TIMEOUT`, sets the
+  `call_timeout` parameter on the `oracle+oracledb` driver (value in
+  milliseconds).  When a query exceeds the limit, the driver cancels it and
+  raises a clean error before the upstream Nginx read timeout fires, giving API
+  clients a meaningful response instead of a silent hang.  When the key is
+  omitted (the default, `None`), no per-call timeout is applied and existing
+  deployments are unaffected.  A value of `270000` (270 s) is recommended for
+  production Oracle deployments — shorter than the typical Nginx 300 s read
+  timeout.  All Oracle test ini files (`gODLDEVL.ini`, `gTEST.ini`,
+  `resources.test/grapinator.ini`) now ship with this value enabled; all SQLite
+  dev ini files carry it as a commented-out example.
+
 ## [2.1.10] - 2026-06-12
 
 ### Changed

--- a/docs/grapinator_ini.md
+++ b/docs/grapinator_ini.md
@@ -269,6 +269,7 @@ not require authentication (e.g. SQLite).  `DB_PASSWORD` supports CryptoConfig e
 | `DB_POOL_TIMEOUT` | No | float | Seconds to block waiting for a free connection before raising a `TimeoutError`.  Set this lower than your upstream client timeout so the caller receives a clean error instead of a silent hang.  *(SQLAlchemy default: 30)* |
 | `DB_POOL_RECYCLE` | No | integer | Seconds after which a pooled connection is proactively replaced.  **Critical for Oracle**: `SQLNET.EXPIRE_TIME` (server-level) and the user-profile `IDLE_TIME` setting will silently close idle connections, producing `ORA-03135` or `ORA-02396` errors.  Set this below the shortest Oracle idle timeout on your server (commonly 1 800 s / 30 min).  Use `-1` to disable recycling (not recommended for Oracle).  *(SQLAlchemy default: -1)* |
 | `DB_POOL_PRE_PING` | No | boolean | When `True` (the default), SQLAlchemy issues a lightweight round-trip before each connection checkout to detect dead connections.  This adds roughly 1 ms per request but prevents `ORA-03135` / `ORA-02396` errors from propagating to API clients.  Set to `False` only on low-latency links where the extra round-trip is undesirable.  *(SQLAlchemy default: False; Grapinator default: True)* |
+| `DB_CALL_TIMEOUT` | No | integer | *(oracle+oracledb only)* Per-call timeout in **milliseconds**.  When a database query runs longer than this limit the driver cancels it and raises a clean error — ensuring the API returns a response before the upstream Nginx read timeout fires.  When omitted (the default), no per-call limit is applied.  Recommended production value: `270000` (270 s, below a typical 300 s Nginx timeout).  Has no effect on SQLite or other non-Oracle dialects. |
 
 The full SQLAlchemy database URI is assembled at runtime:
 
@@ -311,6 +312,8 @@ DB_POOL_TIMEOUT       = 15
 # Recycle connections every 30 min — set below your Oracle IDLE_TIME profile limit.
 DB_POOL_RECYCLE       = 1800
 DB_POOL_PRE_PING      = True
+# Cancel queries that run longer than 270 s so the API replies before Nginx times out.
+DB_CALL_TIMEOUT       = 270000
 ```
 
 > **Oracle idle-session timeout note:** Two mechanisms can silently close idle pool

--- a/grapinator/model.py
+++ b/grapinator/model.py
@@ -44,14 +44,20 @@ if settings.DB_POOL_TIMEOUT is not None:
 if settings.DB_POOL_RECYCLE is not None:
     pool_kwargs['pool_recycle'] = settings.DB_POOL_RECYCLE
 
-engine = create_engine(settings.SQLALCHEMY_DATABASE_URI, **pool_kwargs)
+# Build connect_args — only oracle+oracledb honours call_timeout (milliseconds).
+connect_args = {}
+if settings.DB_CALL_TIMEOUT is not None:
+    connect_args['call_timeout'] = settings.DB_CALL_TIMEOUT
+
+engine = create_engine(settings.SQLALCHEMY_DATABASE_URI, connect_args=connect_args, **pool_kwargs)
 logger.info(
-    'Database engine created: %s  pool_size=%s max_overflow=%s recycle=%s pre_ping=%s',
+    'Database engine created: %s  pool_size=%s max_overflow=%s recycle=%s pre_ping=%s call_timeout=%s',
     settings.DB_TYPE,
     settings.DB_POOL_SIZE,
     settings.DB_POOL_MAX_OVERFLOW,
     settings.DB_POOL_RECYCLE,
     settings.DB_POOL_PRE_PING,
+    settings.DB_CALL_TIMEOUT,
 )
 
 # Scoped session ties a single Session instance to the current thread/request

--- a/grapinator/resources/grapinator.ini
+++ b/grapinator/resources/grapinator.ini
@@ -77,3 +77,4 @@ SQLALCHEMY_TRACK_MODIFICATIONS = False
 # DB_POOL_TIMEOUT       = 15    # Seconds to wait for a free connection (SA default: 30)
 # DB_POOL_RECYCLE       = 1800  # Seconds before recycling; critical for Oracle (SA default: -1)
 # DB_POOL_PRE_PING      = True  # Validate connection health on checkout (recommended: True)
+# DB_CALL_TIMEOUT       = 270000  # Oracle per-call timeout in ms; omit or remove for SQLite

--- a/grapinator/resources/grapinator_rbac.ini
+++ b/grapinator/resources/grapinator_rbac.ini
@@ -81,3 +81,4 @@ SQLALCHEMY_TRACK_MODIFICATIONS = False
 # DB_POOL_TIMEOUT       = 15    # Seconds to wait for a free connection (SA default: 30)
 # DB_POOL_RECYCLE       = 1800  # Seconds before recycling; critical for Oracle (SA default: -1)
 # DB_POOL_PRE_PING      = True  # Validate connection health on checkout (recommended: True)
+# DB_CALL_TIMEOUT       = 270000  # Oracle per-call timeout in ms; omit or remove for SQLite

--- a/grapinator/resources/grapinator_rbac_keycloakdev.ini
+++ b/grapinator/resources/grapinator_rbac_keycloakdev.ini
@@ -62,3 +62,4 @@ SQLALCHEMY_TRACK_MODIFICATIONS = False
 # DB_POOL_TIMEOUT       = 15    # Seconds to wait for a free connection (SA default: 30)
 # DB_POOL_RECYCLE       = 1800  # Seconds before recycling; critical for Oracle (SA default: -1)
 # DB_POOL_PRE_PING      = True  # Validate connection health on checkout (recommended: True)
+# DB_CALL_TIMEOUT       = 270000  # Oracle per-call timeout in ms; omit or remove for SQLite

--- a/grapinator/settings.py
+++ b/grapinator/settings.py
@@ -167,6 +167,7 @@ class Settings(object):
     DB_POOL_TIMEOUT = None        # Seconds to wait for a free connection (SA default: 30)
     DB_POOL_RECYCLE = None        # Seconds before recycling a connection (SA default: -1 = never)
     DB_POOL_PRE_PING = True       # Validate connection health before checkout (recommended: True)
+    DB_CALL_TIMEOUT = None        # Per-call timeout in milliseconds (oracle+oracledb only; None = no limit)
     
     def __init__(self, **kwargs):
         """
@@ -306,6 +307,8 @@ class Settings(object):
                 self.DB_POOL_RECYCLE = properties.getint('SQLALCHEMY', 'DB_POOL_RECYCLE')
             if properties.has_option('SQLALCHEMY', 'DB_POOL_PRE_PING'):
                 self.DB_POOL_PRE_PING = properties.getboolean('SQLALCHEMY', 'DB_POOL_PRE_PING')
+            if properties.has_option('SQLALCHEMY', 'DB_CALL_TIMEOUT'):
+                self.DB_CALL_TIMEOUT = properties.getint('SQLALCHEMY', 'DB_CALL_TIMEOUT')
 
             # load GRAPHENE section
             self.GQL_SCHEMA = properties.get('GRAPHENE', 'GQL_SCHEMA')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = grapinator
-version = 2.1.10
+version = 2.1.11
 author = NREL
 description = Dynamic GraphQL API Creator
 long_description = file: README.md


### PR DESCRIPTION
## Summary

Closes #31

Add a new optional `[SQLALCHEMY]` ini key, `DB_CALL_TIMEOUT` (milliseconds), that sets `call_timeout` on the `oracle+oracledb` `connect_args` so long-running queries are cancelled before Nginx's read timeout fires, returning a clean error to API clients.

## Changes

- **`grapinator/settings.py`** — new `DB_CALL_TIMEOUT` class attribute (default `None`) and optional `has_option`-guarded loader in `__init__`
- **`grapinator/model.py`** — assemble `connect_args` with `call_timeout` when set and pass to `create_engine`; include in startup log message
- **`grapinator/resources/*.ini`** — `DB_CALL_TIMEOUT = 270000` added as a commented-out example to all three SQLite dev ini templates
- **`docs/grapinator_ini.md`** — new row in the `[SQLALCHEMY]` reference table; Oracle example updated
- **`CHANGELOG.md`** — `[2.1.11]` entry
- **`setup.cfg`** — version bumped to `2.1.11`

## Compatibility

When `DB_CALL_TIMEOUT` is absent fWhen `DB_CALL_TI `seWhengs.DB_CALL_TIMEOUT` remains `None` and `connect_args` is passed as an empty dict — identical behaviour to the previous release.  No existing deployments are affected.